### PR TITLE
Avoid django silently ignoring required env vars

### DIFF
--- a/getenv/env.py
+++ b/getenv/env.py
@@ -4,12 +4,10 @@
 import os
 import ast
 
-try:
-    from django.core.exceptions import ImproperlyConfigured
-except ImportError:
-    # If they aren't using django, define our own error
-    class ImproperlyConfigured(Exception):
-        pass
+# We're intentionally not using django.core.exceptions.ImproperlyConfigured
+# because it would be silently ignored by django at settings loading time.
+class ImproperlyConfigured(Exception):
+    pass
 
 
 def env(key, default=None, required=False):


### PR DESCRIPTION
Django silently ignores any ImproperlyConfigured exceptions at settings 
loading time. So a env('WHATEVER', required=True) in settings.py will
cause processing of the file to be silently stopped at the point where
env raised the ImproperlyConfigured exception. This causes hard to 
understand and unexpected results.

This change always raises the custom ImproperlyConfigured exception from
getenv when a required env var has not been set. That exception will 
then be displayed to the user and django will exit as originally 
intended.

Fixes #4